### PR TITLE
Support comments on constraints

### DIFF
--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -982,7 +982,7 @@ class InspectedComment(Inspected):
     @property
     def create_statement(self):
         return "comment on {} {} is '{}';".format(
-            self.object_type, self._identifier, self.comment
+            self.object_type, self._identifier, self.comment.replace("'", "''")
         )
 
     @property

--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -981,8 +981,20 @@ class InspectedComment(Inspected):
 
     @property
     def create_statement(self):
+        # Must explicitly escape single quotes in comments to generate valid SQL
+        escaped_comment = self.comment.replace("'", "''")
+        if self.object_type == "constraint":
+            return "comment on {} {} on {} is '{}';".format(
+                self.object_type,
+                quoted_identifier(self.name),
+                quoted_identifier(self.table, schema=self.schema),
+                escaped_comment
+            )
+
         return "comment on {} {} is '{}';".format(
-            self.object_type, self._identifier, self.comment.replace("'", "''")
+            self.object_type,
+            self._identifier,
+            escaped_comment
         )
 
     @property

--- a/schemainspect/pg/obj.py
+++ b/schemainspect/pg/obj.py
@@ -977,6 +977,12 @@ class InspectedComment(Inspected):
 
     @property
     def drop_statement(self):
+        if self.object_type == "constraint":
+            return "comment on {} {} on {} is null;".format(
+                self.object_type,
+                quoted_identifier(self.name),
+                quoted_identifier(self.table, schema=self.schema)
+            )
         return "comment on {} {} is null;".format(self.object_type, self._identifier)
 
     @property

--- a/schemainspect/pg/sql/comments.sql
+++ b/schemainspect/pg/sql/comments.sql
@@ -51,4 +51,20 @@ from
 where
     n.nspname <> 'pg_catalog'
     and n.nspname <> 'information_schema'
-    and pg_catalog.col_description(c.oid, a.attnum) is not null;
+    and pg_catalog.col_description(c.oid, a.attnum) is not null
+union all
+select
+    'constraint',
+    n.nspname,
+    c.relname,
+    con.conname,
+    NULL,
+    pg_catalog.obj_description(con.oid, 'pg_constraint')
+from
+    pg_catalog.pg_constraint con
+        join pg_catalog.pg_class c on c.oid = con.conrelid
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+where
+  n.nspname <> 'pg_catalog'
+  and n.nspname <> 'information_schema'
+  and pg_catalog.obj_description(con.oid, 'pg_constraint') is not null;

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -248,6 +248,7 @@ def setup_pg_schema(s):
         grant select, update, delete, insert on table films to postgres;
     """
     )
+    s.execute("comment on constraint firstkey on films is 'a constraint comment'")
     s.execute("""CREATE VIEW v_films AS (select * from films)""")
     s.execute("""CREATE VIEW v_films2 AS (select * from v_films)""")
     s.execute(
@@ -499,7 +500,7 @@ $$;""".format(
         tid.change_string_to_enum_statement("t")
 
     # comments
-    assert len(i.comments) == 2
+    assert len(i.comments) == 3
     assert (
         i.comments[
             'function "public"."films_f"(d date, def_t text, def_d date)'
@@ -509,6 +510,10 @@ $$;""".format(
     assert (
         i.comments['table "public"."emptytable"'].create_statement
         == 'comment on table "public"."emptytable" is \'emptytable comment\';'
+    )
+    assert (
+        i.comments['constraint "public"."films"."firstkey"'].create_statement
+        == 'comment on constraint "public"."films"."firstkey" is \'a constraint comment\';'
     )
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -513,7 +513,7 @@ $$;""".format(
     )
     assert (
         i.comments['constraint "public"."films"."firstkey"'].create_statement
-        == """comment on constraint "public"."films"."firstkey" is 'a ''constraint'' comment';"""
+        == """comment on constraint "firstkey" on "public"."films" is 'a ''constraint'' comment';"""
     )
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -248,7 +248,7 @@ def setup_pg_schema(s):
         grant select, update, delete, insert on table films to postgres;
     """
     )
-    s.execute("comment on constraint firstkey on films is 'a constraint comment'")
+    s.execute("comment on constraint firstkey on films is E'a \\'constraint\\' comment'")
     s.execute("""CREATE VIEW v_films AS (select * from films)""")
     s.execute("""CREATE VIEW v_films2 AS (select * from v_films)""")
     s.execute(
@@ -513,7 +513,7 @@ $$;""".format(
     )
     assert (
         i.comments['constraint "public"."films"."firstkey"'].create_statement
-        == 'comment on constraint "public"."films"."firstkey" is \'a constraint comment\';'
+        == """comment on constraint "public"."films"."firstkey" is 'a ''constraint'' comment';"""
     )
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -508,12 +508,22 @@ $$;""".format(
         == 'comment on function "public"."films_f"(d date, def_t text, def_d date) is \'films_f comment\';'
     )
     assert (
+            i.comments[
+                'function "public"."films_f"(d date, def_t text, def_d date)'
+            ].drop_statement
+            == 'comment on function "public"."films_f"(d date, def_t text, def_d date) is null;'
+    )
+    assert (
         i.comments['table "public"."emptytable"'].create_statement
         == 'comment on table "public"."emptytable" is \'emptytable comment\';'
     )
     assert (
         i.comments['constraint "public"."films"."firstkey"'].create_statement
         == """comment on constraint "firstkey" on "public"."films" is 'a ''constraint'' comment';"""
+    )
+    assert (
+            i.comments['constraint "public"."films"."firstkey"'].drop_statement
+            == """comment on constraint "firstkey" on "public"."films" is null;"""
     )
 
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -508,10 +508,10 @@ $$;""".format(
         == 'comment on function "public"."films_f"(d date, def_t text, def_d date) is \'films_f comment\';'
     )
     assert (
-            i.comments[
-                'function "public"."films_f"(d date, def_t text, def_d date)'
-            ].drop_statement
-            == 'comment on function "public"."films_f"(d date, def_t text, def_d date) is null;'
+        i.comments[
+            'function "public"."films_f"(d date, def_t text, def_d date)'
+        ].drop_statement
+        == 'comment on function "public"."films_f"(d date, def_t text, def_d date) is null;'
     )
     assert (
         i.comments['table "public"."emptytable"'].create_statement
@@ -522,8 +522,8 @@ $$;""".format(
         == """comment on constraint "firstkey" on "public"."films" is 'a ''constraint'' comment';"""
     )
     assert (
-            i.comments['constraint "public"."films"."firstkey"'].drop_statement
-            == """comment on constraint "firstkey" on "public"."films" is null;"""
+        i.comments['constraint "public"."films"."firstkey"'].drop_statement
+        == """comment on constraint "firstkey" on "public"."films" is null;"""
     )
 
 


### PR DESCRIPTION
Updated the SQL to introspect comments to also look for comments on constraints.

Also added support for comments that have quotes inside of them by explicitly escaping the quotes. Note that other special escape characters may not be supported, but things like newlines or tab characters won't make the SQL that migra generates invalid. 

## To Test
Before going through these tests, point your migra to this branch of schemainspect in the TOML, then rerun `poetry install` for your environment. You may also want to consider creating a new environment just for this testing.
- [x] Add a comment to a constraint. Run migra against two databases, one without the constraint, and verify it properly generates the comment SQL
- [x] Add some quotes inside of the comment and rerun migra. Verify that the SQL migra generates is valid.
- [x] Test that migra can also generate diffs where the comment is cleared out for the constraint, i.e. set to `null`